### PR TITLE
fix: update Android project for Capacitor 7

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    namespace "com.example.moontide"
+    namespace "com.moontide.app"
     compileSdk rootProject.ext.compileSdkVersion
 
     defaultConfig {
-        applicationId "com.example.moontide"
+        applicationId "com.moontide.app"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
@@ -25,6 +25,15 @@ android {
                           'proguard-rules.pro'
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 repositories {
@@ -39,7 +48,7 @@ repositories {
 
 dependencies {
     // Capacitor native runtime (required for BridgeActivity)
-    implementation 'com.getcapacitor:capacitor-android:4.8.0'
+    implementation 'com.getcapacitor:capacitor-android:7.4.0'
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -2,8 +2,8 @@
 
 android {
   compileOptions {
-      sourceCompatibility JavaVersion.VERSION_21
-      targetCompatibility JavaVersion.VERSION_21
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
   }
 }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.moontide.app">
 
     <application
         android:allowBackup="true"

--- a/android/app/src/main/java/com/moontide/app/MainActivity.java
+++ b/android/app/src/main/java/com/moontide/app/MainActivity.java
@@ -1,4 +1,4 @@
-package com.example.moontide;
+package com.moontide.app;
 
 import com.getcapacitor.BridgeActivity;
 

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">MoonTide</string>
     <string name="title_activity_main">MoonTide</string>
-    <string name="package_name">com.example.moontide</string>
-    <string name="custom_url_scheme">com.example.moontide</string>
+    <string name="package_name">com.moontide.app</string>
+    <string name="custom_url_scheme">com.moontide.app</string>
 </resources>


### PR DESCRIPTION
## Summary
- align Android project with Capacitor 7 and use package `com.moontide.app`
- set Java compatibility to 17
- move `MainActivity` into new package structure

## Testing
- `npm test` *(fails: vitest not found / missing jsdom)*
- `npm run lint` *(fails: Unexpected any in MoonCalendar.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6893dd02ac44832d950f91170220685a