### PR TITLE
feat(android): enable Kotlin Gradle plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 android {
     namespace "com.moontide.app"

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,6 +11,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.7.2'
         classpath 'com.google.gms:google-services:4.4.2'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
## Summary
- add Kotlin Gradle plugin dependency
- apply Kotlin Android plugin to app module

## Testing
- `gradle assembleDebug` *(fails: Could not resolve com.android.tools.build:gradle:8.7.2 - Received status code 403 from server: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6894ffd06538832dbf14a2ca6fa36084